### PR TITLE
Merging upstream, fixing #2, review comments

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,10 +15,10 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install dependencies
-    - name: Set up Python 3.7
+    - name: Set up Python 
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9.21
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     - uses: actions/checkout@v2
 
     # Install dependencies
-    - name: Set up Python 3.7
+    - name: Set up Python 
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: '3.x'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: 3.9.21
 
     - name: Install dependencies
       run: |

--- a/docs/contributing/format.md
+++ b/docs/contributing/format.md
@@ -1,11 +1,12 @@
 # Format of content
+## Adding new markdown files
+Add your **markdown files** to the section folders under `docs` and register the file in `docs/_toc.yml`.
 
-In this repository, we store FAIR-IO materials using Markdown and for links we use a simple YML format. 
+## Adding links to external resources
+The **YML** files under `resources/` contain
+metadata about contributed material that is already published elsewhere.
 
-Add **Markdown files** to the section folders under `docs` and register the file in `docs/_toc.yml`.
-
-The **YML files** in `resources` are structured like this:
-
+Their structure is examplified here:
 ```
 resources
 - name: NFDI4BioImage Website
@@ -15,15 +16,16 @@ resources
   url: https://nfdi4bioimage.de 
 ```
 
-These entries can have multiple properties:
-
+Each entry is attributed by various properties such as
 * `name` (mandatory): A descriptive title of the resource
 * `url` (mandatory): Resources must be available on the internet using a URL or DOI-URL.
 * `type` (mandatory): Content types such as `video`, `collection`, `blog post` etc. Resources can have multiple content types. Collections are lists of links, which could potentially contain more entries.
-* `license` (optional, recommended)
+* `license` (mandatory)
 * `description` (optional)
 * `publication_date` (optional)
 * `authors` (optional)
 * `tags` (optional)
 
 This list of meta-data entries is extensible, just let us know using a [github-issue](https://github.com/NFDI4BIOIMAGE/FAIR-IO/issues) which kind of meta data you would like to add here.
+
+After pushing newly added material to your own fork, you can create a pull request to inform us about your suggested additions or modifications to existing material.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,14 +1,21 @@
 # How to contribute
 
-This repository is extensible using github pull requests. You find a how-to guide on the bottom of this page. The format for entries in the repository is documented on the next page.
-
-# Quick contributing short-cut:
-
-If you're too busy to enter everything in detail yourself, please just create a [github issue](https://github.com/NFDI4BIOIMAGE/FAIR-IO/issues) with content or links to the materials you want to include. We can take of all the details.
+In this repository, we collect materials on FAIR-IO. Materials come in various types, from academic journal articles to
+blog posts, online videos, teaching resources, slide decks, source code, ... . New material can be contributed
+as a markdown file or as a link to external resources. This procedure requires that you have forked this repository
+to your own github account. All changes are first applied to your own fork. Later, you then create a pull request (PR)
+in **this** repository. We will then review your proposed changes and integrate them into the website.
 
 ## What to contribute
-
-TODO
+- Documentation of creating, uploading, sharing, publishing FAIR-IOs
+  - Markdown documents (including converted jupyter notebooks)
+  - Academic journal articles and preprints
+  - Technical reports and specifications
+  - Blog posts
+  - Events (workshops, conferences)
+  - Educational material 
+  - Source code, workflow definitions
+  - ...
 
 ## Inclusion criteria
 
@@ -23,7 +30,33 @@ TODO
 We reserve the right to remove and modify entries of this collection at any point in time.
 
 ## Step-by-step tutorial
+1. Clone this repository
+1. **Markdown** document
+    1. Edit or create new **Markdown** file under `docs/`. Create new section directory if required.
+    1. Add path of new **Markdown** document in `docs/_toc.yml`.
+1. **YML** document
+    1. Edit or create new **YML** entry under `resources/` in one of the existing **YML** files or create a new **YML** file.
+    1. Mandatory properties:
+      - `name`
+      - `url`
+      - `type`
+      - `license`
+    1. Optional properties:
+      - `description`
+      - `publication_date`
+      - `authors`
+      - `tags`
+    Note that the specific license applied to linked material might enforce the attribution of properties not mentioned here. E.g. the CC-BY
+    license mandates the attribution of the original copyright owners, hence `authors` would then be a mandatory field, not just optional.
+1. Save all files and commit to your repository
+1. Push your changes to your github fork
+1. Create a pull request at https://github.com/NFDI4BIOIMAGE/FAIR-IO/compare
+   1. Select your fork/branch as **source** and `base:main` as target.
+   1. Be as verbose as possible about the details of your proposed changes.
+   1. Optional: Propose a reviewer
 
-TODO
+# At the minimum ...
+
+If the above procedure seems too daunting or time consuming, create a [github issue](https://github.com/NFDI4BIOIMAGE/FAIR-IO/issues) with content or links to the materials you want to include. We can take care of all the details.
 
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,30 +1,25 @@
 # FAIR-IO
+FAIR-IO (FAIR Image Object): A cloud-compatible format for bioimage data and metadata according to the [FAIR principles](https://www.go-fair.org/fair-principles).
+
 
 Here you will find **standards**, **tooling** and **best practices** for “FAIR Image Objects” (FAIR-IO) in the bioimaging community.
 The entities described are intended to promote the reuse and exchange of bioimaging data.
 
 
-$\color{#D29922}\textsf{Warning: This knowledge base isn't complete.}$ 
-
-
-
-
-Feedback and contributions are very welcome, e.g. as [github issue](https://github.com/NFDI4BIOIMAGE/FAIR-IO/issues).
-
+$\color{#D29922}\textsf{Warning: This knowledge base isn't complete}$ 
 
 
 ## Contributing
+**Feedback and contributions are very welcome!**
 
-Contributions are welcome. Consider adding your favorite training resources so that we can make sure that they are findable and reusable.
-You find instructions in how to contribute on the contributing page.
+You find instructions in how to contribute on the [contributing page](/Contributing), e.g. as [github issue](https://github.com/NFDI4BIOIMAGE/FAIR-IO/issues).
+Consider adding your favorite training resources so we can make sure they are findable and reusable.
 
 ## License
-
-All contents of this Jupyter book and the corresponding Github repository are licensed [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/), unless mentioned otherwise.
+All contents of this Jupyter book and the corresponding Github repository are licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/), unless mentioned otherwise.
 
 
 ## Acknowledgements
-
 This project is funded by the Deutsche Forschungsgemeinschaft (DFG, German  Research Foundation) under the National Research Data Infrasstructure – NFDI 46/1 – 501864659.
 
 

--- a/docs/specification/index.md
+++ b/docs/specification/index.md
@@ -1,8 +1,10 @@
 # What is a FAIR-IO
-A FAIR-IO bundle combines the necessary acquisition and provenance metadata together with multi-resolution, chunked binary data in a single cloud-compatible format for simplified sharing and re-use.
+A FAIR-IO (FAIR Image Object) bundle combines acquisition and provenance metadata together with multi-resolution, chunked binary pixel data in a single cloud-compatible format for simplified sharing and re-use. As such, FAIR-IO implements
+a FAIR Digital Object (FDO, DOI:10.5281/zenodo.7824714) as illustrated below.
 
 ![FAIR-IO concept](FAIR-IO_10.5281-zenodo.10512531.png)
 
+FAIR-IO is based on the following recommendations for binary (pixel) data and textual metadata.
 ## Recommendations for easily sharable binary data: 
 <div>
 <table style="margin-left:5px;">
@@ -13,7 +15,7 @@ A FAIR-IO bundle combines the necessary acquisition and provenance metadata toge
           <li>Use data formats that store binary data with multiple resolutions in a single cloud-compatible, chunkable format. These enable web-optimised data access and high-performance cloud storage</li>
           <li>Store data in a public available space accessible via a data specific URL</li> 
         </ul>
-        <b>Serialization example:</b> ome-zarr (<a href="https://doi.org/10.1007/s00418-023-02209-1"> About</a> |<a href=""> Tools</a>)
+        <b>Example format:</b> ome-zarr (<a href="https://doi.org/10.1007/s00418-023-02209-1"> About</a> |<a href=""> Tools</a>)
     </td>
 </tr>
 
@@ -32,10 +34,9 @@ A FAIR-IO bundle combines the necessary acquisition and provenance metadata toge
           <li>Use metadata formats that store metadata in a machine readable form, that means </li>
           <li>store data in a public available space accessible via a data specific URL</li> 
         </ul>
-        <b>Serialization example:</b> JSONLD (<a href=""> About</a> |<a href=""> Tools</a>), Turtle (<a href=""> About</a> |<a href=""> Tools</a>)
+        <b>Example formats:</b> JSON-LD (<a href=""> About</a> |<a href=""> Tools</a>), Turtle (<a href=""> About</a> |<a href=""> Tools</a>)
     </td>
 </tr>
-
 </table>
 </div>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jupyter-book>=0.7.0b
 sphinx-book-theme<1.0.0
 matplotlib
+sphinx>=7.4.7
 numpy
 


### PR DESCRIPTION
This PR pulls in changes from the upstream repository and adds `sphinx` with minimal version 7.4.7 addressing issue #2

In addition, I rewrote some parts of the website in an effort to streamline it a bit and sort bits and pieces into a more consistent structure (hopefully).

## General remarks
The frontpage should make it much clearer that this website is meant as a knowledge base for various types of resources around the subject of FAIR-IO. At first sight it could be misread as a place where FAIR-IO is defined (as in a standard or technical specification). With that it mind, the section 'Specifiations' should maybe be renamed or rewritten as a proper specification, currently it's a couple of recommendations.

There are already quite a number of resources under `resources/` but I don't see them rendered in the built website.

To formalize the process of adding new linked material as a yml file, I would suggest to create a template issue where
the mandatory and optional fields are already predefined. Another template issue for adding new yml metadata terms may also be helpful.